### PR TITLE
Fix display in dark theme

### DIFF
--- a/src/dalf/admin.py
+++ b/src/dalf/admin.py
@@ -31,6 +31,7 @@ class DALFModelAdmin(admin.ModelAdmin):
             css={
                 'screen': (
                     'admin/css/vendor/select2/select2.min.css',
+                    'admin/css/autocomplete.css',
                     'admin/css/django_admin_list_filter.css',
                 ),
             },

--- a/src/dalf/templates/admin/filter/django_admin_list_filter.html
+++ b/src/dalf/templates/admin/filter/django_admin_list_filter.html
@@ -7,7 +7,7 @@
         <ul>
             <li>
                 {% with params=choices|last %}
-                    <select class="django-admin-list-filter" name="{{ params.field_name }}" data-is-choices-filter="{{ params.is_choices_filter }}">
+                    <select class="django-admin-list-filter admin-autocomplete" name="{{ params.field_name }}" data-is-choices-filter="{{ params.is_choices_filter }}" data-theme="admin-autocomplete">
                     {% for choice in choices %}
                         {% if choice.display %}<option value="{{ choice.query_string|iriencode }}"{% if choice.selected %} selected{% endif %}>{{ choice.display }}</option>{% endif %}
                     {% endfor %}

--- a/src/dalf/templates/admin/filter/django_admin_list_filter_ajax.html
+++ b/src/dalf/templates/admin/filter/django_admin_list_filter_ajax.html
@@ -18,6 +18,7 @@
                       data-allow-clear="true"
                       data-app-label="{{ params.app_label }}"
                       data-model-name="{{ params.model_name }}"
+                      data-theme="admin-autocomplete"
                       data-field-name="{{ params.field_name }}"></select>
                 {% endwith %}
               </li>

--- a/tests/testproject/testapp/tests.py
+++ b/tests/testproject/testapp/tests.py
@@ -41,8 +41,8 @@ def test_post_admin_filters_basics(admin_client, posts):  # noqa: ARG001
 
             if option_field_name in ['author', 'audience']:
                 assert (
-                    f'<select class="django-admin-list-filter" name="{option_field_name}" '
-                    f'data-is-choices-filter="{option_is_choices_filter}">'
+                    f'<select class="django-admin-list-filter admin-autocomplete" name="{option_field_name}" '
+                    f'data-is-choices-filter="{option_is_choices_filter}" data-theme="admin-autocomplete">'
                 ) in content
 
             if option_field_name == 'author':


### PR DESCRIPTION
## Description

The orignal DALF has bad display in dark mode:

![image](https://github.com/user-attachments/assets/59b579f5-2b18-445e-b510-8b3aa4b7a53e)

Here is after the fix:

![image](https://github.com/user-attachments/assets/4fc3e9f1-59d6-4cb9-b190-73c8907725c6)

## Related Issue(s)

This pull request is related to issue(s) #.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Just replace original DALF with this [fork](https://github.com/AgriConnect/django-admin-list-filter/tree/fix/dark-theme-django-v5).

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.
