### PR TITLE
Support models with primary keys not named "id"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.10.0
+    rev: v0.11.0
     hooks:
       - id: ruff
   - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.3
+    rev: v0.10.0
     hooks:
       - id: ruff
   - repo: local
@@ -9,4 +9,5 @@ repos:
         name: pytest
         entry: pytest -s tests/testproject/testapp -c tests/testproject/pytest.ini
         language: system
-        types: [python]
+        pass_filenames: false
+        types_or: [python, html]

--- a/src/dalf/admin.py
+++ b/src/dalf/admin.py
@@ -1,5 +1,4 @@
 # ruff: noqa: PLR0913,ARG002,SLF001
-import json
 
 from django import forms
 from django.contrib import admin
@@ -47,7 +46,6 @@ class DALFMixin:
             'app_label': model._meta.app_label,
             'model_name': model._meta.model_name,
             'field_name': field_path,
-            'is_choices_filter': json.dumps(obj=False),
             'lookup_kwarg': self.lookup_kwarg,
         }
 
@@ -67,9 +65,7 @@ class DALFRelatedOnlyField(DALFMixin, admin.RelatedOnlyFieldListFilter):
 
 
 class DALFChoicesField(DALFMixin, admin.ChoicesFieldListFilter):
-    def __init__(self, field, request, params, model, model_admin, field_path):
-        super().__init__(field, request, params, model, model_admin, field_path)
-        self.custom_template_params.update({'is_choices_filter': json.dumps(obj=True)})
+    pass
 
 
 class DALFRelatedFieldAjax(admin.RelatedFieldListFilter):

--- a/src/dalf/admin.py
+++ b/src/dalf/admin.py
@@ -7,11 +7,11 @@ from django.contrib.admin.widgets import get_select2_language
 from django.urls import reverse
 
 __all__ = [
+    'DALFChoicesField',
     'DALFModelAdmin',
     'DALFRelatedField',
-    'DALFRelatedOnlyField',
-    'DALFChoicesField',
     'DALFRelatedFieldAjax',
+    'DALFRelatedOnlyField',
 ]
 
 
@@ -48,6 +48,7 @@ class DALFMixin:
             'model_name': model._meta.model_name,
             'field_name': field_path,
             'is_choices_filter': json.dumps(obj=False),
+            'lookup_kwarg': self.lookup_kwarg,
         }
 
     def choices(self, changelist):
@@ -83,6 +84,7 @@ class DALFRelatedFieldAjax(admin.RelatedFieldListFilter):
             'model_name': model._meta.model_name,
             'field_name': field_path,
             'ajax_url': reverse('admin:autocomplete'),
+            'lookup_kwarg': self.lookup_kwarg,
         }
         selected_value = originial_params.get(self.lookup_kwarg, [])
         self.selected_value = selected_value[0] if selected_value else None

--- a/src/dalf/static/admin/js/django_admin_list_filter.js
+++ b/src/dalf/static/admin/js/django_admin_list_filter.js
@@ -8,8 +8,9 @@
             const appLabel = element.dataset.appLabel;
             const modelName = element.dataset.modelName;
             const fieldName = element.dataset.fieldName;
+            const lookupKwarg = element.dataset.lookupKwarg;
             const selectedValue = $(element).prev('.djal-selected-value').val();
-            
+
             $(element).select2({
                 ajax: {
                     data: (params) => {
@@ -25,17 +26,15 @@
             }).on('select2:select', function(e){
                var data = e.params.data;
                var navURL = new URL(window.location.href);
-               var queryParam = fieldName + "__id__exact";
 
-               navURL.searchParams.set(queryParam, decodeURIComponent(data.id));
+               navURL.searchParams.set(lookupKwarg, decodeURIComponent(data.id));
                window.location.href = navURL.href;
             }).on("select2:unselect", function(e){
                 var navURL = new URL(window.location.href);
-                var queryParam = fieldName + "__id__exact";
-                navURL.searchParams.delete(queryParam);
+                navURL.searchParams.delete(lookupKwarg);
                 window.location.href = navURL.href;
             });
-            
+
             if (selectedValue){
                 $.ajax({
                     url: ajaxURL,
@@ -57,14 +56,13 @@
                     }
                 });
             }
-            
+
         });
         return this;
     };
-    
+
     function getQueryParams(e, isChoicesFilter) {
-        var fieldName = e.target.name;
-        var fieldQueryParam = isChoicesFilter ? `${fieldName}__exact` : `${fieldName}__id__exact`;
+        var fieldQueryParam = $(e.target).data('lookupKwarg');
         var data = e.params.data;
         var selected = data.id.replace(/\?/, "");
         var queryParams = selected.split("&");

--- a/src/dalf/static/admin/js/django_admin_list_filter.js
+++ b/src/dalf/static/admin/js/django_admin_list_filter.js
@@ -61,7 +61,7 @@
         return this;
     };
 
-    function getQueryParams(e, isChoicesFilter) {
+    function getQueryParams(e) {
         var fieldQueryParam = $(e.target).data('lookupKwarg');
         var data = e.params.data;
         var selected = data.id.replace(/\?/, "");
@@ -94,7 +94,7 @@
             placeholder: getTextSafe("Filter")
         }).on("select2:select", function(e){
             var navURL = new URL(window.location.href);
-            let [fieldQueryParam, queryParams] = getQueryParams(e, $(this).data("isChoicesFilter"));
+            let [fieldQueryParam, queryParams] = getQueryParams(e);
             var isAllorEmptyChoice = true;
 
             queryParams.forEach(function(item){
@@ -111,7 +111,7 @@
 
         }).on("select2:unselect", function(e){
             var navURL = new URL(window.location.href);
-            let [fieldQueryParam, queryParams] = getQueryParams(e, $(this).data("isChoicesFilter"));
+            let [fieldQueryParam, queryParams] = getQueryParams(e);
 
             queryParams.forEach(function(item){
                 var [field, value] = item.split("=");

--- a/src/dalf/templates/admin/filter/django_admin_list_filter.html
+++ b/src/dalf/templates/admin/filter/django_admin_list_filter.html
@@ -7,7 +7,13 @@
         <ul>
             <li>
                 {% with params=choices|last %}
-                    <select class="django-admin-list-filter admin-autocomplete" name="{{ params.field_name }}" data-is-choices-filter="{{ params.is_choices_filter }}" data-theme="admin-autocomplete">
+                    <select
+                        class="django-admin-list-filter admin-autocomplete"
+                        name="{{ params.field_name }}"
+                        data-lookup-kwarg="{{ params.lookup_kwarg }}"
+                        data-is-choices-filter="{{ params.is_choices_filter }}"
+                        data-theme="admin-autocomplete"
+                    >
                     {% for choice in choices %}
                         {% if choice.display %}<option value="{{ choice.query_string|iriencode }}"{% if choice.selected %} selected{% endif %}>{{ choice.display }}</option>{% endif %}
                     {% endfor %}

--- a/src/dalf/templates/admin/filter/django_admin_list_filter.html
+++ b/src/dalf/templates/admin/filter/django_admin_list_filter.html
@@ -11,7 +11,6 @@
                         class="django-admin-list-filter admin-autocomplete"
                         name="{{ params.field_name }}"
                         data-lookup-kwarg="{{ params.lookup_kwarg }}"
-                        data-is-choices-filter="{{ params.is_choices_filter }}"
                         data-theme="admin-autocomplete"
                     >
                     {% for choice in choices %}

--- a/src/dalf/templates/admin/filter/django_admin_list_filter_ajax.html
+++ b/src/dalf/templates/admin/filter/django_admin_list_filter_ajax.html
@@ -18,6 +18,7 @@
                       data-allow-clear="true"
                       data-app-label="{{ params.app_label }}"
                       data-model-name="{{ params.model_name }}"
+                      data-lookup-kwarg="{{ params.lookup_kwarg }}"
                       data-theme="admin-autocomplete"
                       data-field-name="{{ params.field_name }}"></select>
                 {% endwith %}

--- a/tests/testproject/testapp/admin.py
+++ b/tests/testproject/testapp/admin.py
@@ -8,7 +8,7 @@ from dalf.admin import (
     DALFRelatedOnlyField,
 )
 
-from .models import Category, Post, Tag
+from .models import Category, CategoryRenamed, Post, Tag
 
 
 @admin.register(Post)
@@ -18,12 +18,19 @@ class PostAdmin(DALFModelAdmin):
         ('author', DALFRelatedField),
         ('audience', DALFChoicesField),
         ('category', DALFRelatedFieldAjax),
+        ('category_renamed', DALFRelatedFieldAjax),
         ('tags', DALFRelatedOnlyField),
     )
 
 
 @admin.register(Category)
 class CategoryAdmin(admin.ModelAdmin):
+    search_fields = ('name',)
+    ordering = ('name',)
+
+
+@admin.register(CategoryRenamed)
+class CategoryRenamedAdmin(admin.ModelAdmin):
     search_fields = ('name',)
     ordering = ('name',)
 

--- a/tests/testproject/testapp/conftest.py
+++ b/tests/testproject/testapp/conftest.py
@@ -10,3 +10,7 @@ register(PostFactory)
 @pytest.fixture
 def posts():
     return PostFactory.create_batch(10)
+
+@pytest.fixture
+def unused_tag():
+    return TagFactory(name='Unused')

--- a/tests/testproject/testapp/factories.py
+++ b/tests/testproject/testapp/factories.py
@@ -2,7 +2,7 @@ import factory
 from django.contrib.auth import get_user_model
 from factory import fuzzy
 
-from .models import AudienceChoices, Category, Post, Tag
+from .models import AudienceChoices, Category, CategoryRenamed, Post, Tag
 
 FAKE_USERNAMES = [
     'vigo',
@@ -47,6 +47,14 @@ class CategoryFactory(factory.django.DjangoModelFactory):
     name = factory.Iterator(FAKE_CATEGORIES)
 
 
+class CategoryRenamedFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = CategoryRenamed
+        django_get_or_create = ('name',)
+
+    name = factory.Iterator(FAKE_CATEGORIES)
+
+
 class TagFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Tag
@@ -62,6 +70,7 @@ class PostFactory(factory.django.DjangoModelFactory):
 
     author = factory.SubFactory(UserFactory)
     category = factory.SubFactory(CategoryFactory)
+    category_renamed = factory.SubFactory(CategoryRenamedFactory)
     title = factory.Sequence(lambda n: f'Book about {FAKE_CATEGORIES[n % len(FAKE_CATEGORIES)]} - {n}')
     audience = fuzzy.FuzzyChoice(AudienceChoices.choices, getter=lambda c: c[0])
 

--- a/tests/testproject/testapp/models.py
+++ b/tests/testproject/testapp/models.py
@@ -1,8 +1,18 @@
+import uuid
+
 from django.conf import settings
 from django.db import models
 
 
 class Category(models.Model):
+    name = models.CharField(max_length=255)
+
+    def __str__(self):
+        return self.name
+
+
+class CategoryRenamed(models.Model):
+    renamed_id = models.UUIDField(default=uuid.uuid4, primary_key=True)
     name = models.CharField(max_length=255)
 
     def __str__(self):
@@ -30,6 +40,11 @@ class Post(models.Model):
     )
     category = models.ForeignKey(
         to='Category',
+        on_delete=models.CASCADE,
+        related_name='posts',
+    )
+    category_renamed = models.ForeignKey(
+        to='CategoryRenamed',
         on_delete=models.CASCADE,
         related_name='posts',
     )

--- a/tests/testproject/testapp/tests.py
+++ b/tests/testproject/testapp/tests.py
@@ -65,7 +65,6 @@ def test_post_admin_filters_basics(admin_client, posts):  # noqa: ARG001
             filter_choices = list(spec.choices(response.context['cl']))
             filter_custom_options = filter_choices.pop()
             option_field_name = filter_custom_options.get('field_name', None)
-            option_is_choices_filter = filter_custom_options.get('is_choices_filter', None)
 
             if option_field_name in ['author', 'audience']:
                 maybe_id_suffix = '__id' if option_field_name == 'author' else ''
@@ -73,7 +72,6 @@ def test_post_admin_filters_basics(admin_client, posts):  # noqa: ARG001
                     {
                         'class': 'django-admin-list-filter admin-autocomplete',
                         'name': option_field_name,
-                        'data-is-choices-filter': option_is_choices_filter,
                         'data-lookup-kwarg': f'{option_field_name}{maybe_id_suffix}__exact',
                         'data-theme': 'admin-autocomplete',
                     },
@@ -83,20 +81,14 @@ def test_post_admin_filters_basics(admin_client, posts):  # noqa: ARG001
                 validator.check(content)
 
             if option_field_name == 'author':
-                assert option_is_choices_filter == 'false'
                 for author in post_authors:
                     assert f'{author}</option>' in content
 
             if option_field_name == 'audience':
-                assert option_is_choices_filter == 'true'
                 for audience in post_audiences:
                     assert f'<option value="?audience__exact={audience}">' in content
 
-            if option_field_name == 'tags':
-                assert option_is_choices_filter == 'false'
-
             if option_field_name == 'category':
-                assert option_is_choices_filter is None
                 assert 'data-field-name="category"></select>' in content
 
                 url_params = '&'.join(

--- a/tests/testproject/testapp/tests.py
+++ b/tests/testproject/testapp/tests.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 
 from dalf.admin import DALFChoicesField, DALFRelatedField, DALFRelatedFieldAjax, DALFRelatedOnlyField
 
-from .models import Post
+from .models import Post, Tag
 
 csrf_token_pattern = re.compile(r'name="csrfmiddlewaretoken" value="([^"]+)"')
 
@@ -19,12 +19,14 @@ class MatchingTagValidator(HTMLParser):
     Instances of this class are not reusable. Create a new one for every ``check`` call.
     """
 
-    def __init__(self, expected_attrs, matcher_attrs, tag):
+    def __init__(self, tag, matcher_attrs, expected_attrs, expected_content=None):
         super().__init__()
-        self.expected_attrs = expected_attrs
         self.matcher_attrs = matcher_attrs
         self.target_tag = tag
+        self.expected_attrs = expected_attrs
+        self.expected_content = expected_content
         self.seen_target_tag = False
+        self.inside_target_tag = False
 
     def check(self, content):
         self.feed(content)
@@ -35,19 +37,35 @@ class MatchingTagValidator(HTMLParser):
             return
         attrs = dict(attrs)
         if self.matcher_attrs.items() <= attrs.items():
+            self.inside_target_tag = True
             assert not self.seen_target_tag, 'Multiple matching tags found'
             self.seen_target_tag = True
             assert self.expected_attrs.items() <= attrs.items()
 
+    def handle_endtag(self, tag):
+        if tag == self.target_tag:
+            # Yes, this will be incorrect with nested tags of same kind. We don't need
+            # nested tags at all.
+            self.inside_target_tag = False
+
+    def handle_data(self, data):
+        if self.inside_target_tag and self.expected_content is not None:
+            assert data.strip() == self.expected_content
+
+
 
 @pytest.mark.django_db
-def test_post_admin_filters_basics(admin_client, posts):  # noqa: ARG001
+@pytest.mark.usefixtures('posts')
+def test_post_admin_filters_basics(admin_client, unused_tag):
     posts_count = 10
-    post_authors = set(Post.objects.values_list('author__username', flat=True))
-    post_audiences = set(Post.objects.values_list('audience', flat=True))
+    post_authors = dict(Post.objects.values_list('author__id', 'author__username'))
+    post_audiences = {p.audience: p.get_audience_display() for p in Post.objects.all()}
+    post_tags = dict(Tag.objects.filter(post__isnull=False).distinct().values_list('id', 'name'))
 
     assert post_authors
     assert post_audiences
+    assert post_tags
+    target_options = {'author': post_authors, 'audience': post_audiences, 'tags': post_tags}
 
     response = admin_client.get(reverse('admin:testapp_post_changelist'))
     assert response.status_code == HTTPStatus.OK
@@ -60,36 +78,60 @@ def test_post_admin_filters_basics(admin_client, posts):  # noqa: ARG001
 
     assert len(filter_specs) > 0
 
+    expected_lookup_kwargs = {
+        'author': 'author__id__exact',
+        'audience': 'audience__exact',
+        'category': 'category__id__exact',
+        'category_renamed': 'category_renamed__renamed_id__exact',
+        'tags': 'tags__id__exact',
+    }
+
     for spec in filter_specs:
         if isinstance(spec, (DALFRelatedField, DALFChoicesField, DALFRelatedFieldAjax, DALFRelatedOnlyField)):
             filter_choices = list(spec.choices(response.context['cl']))
             filter_custom_options = filter_choices.pop()
-            option_field_name = filter_custom_options.get('field_name', None)
+            option_field_name = filter_custom_options['field_name']
 
-            if option_field_name in ['author', 'audience']:
-                maybe_id_suffix = '__id' if option_field_name == 'author' else ''
+            lookup_kwarg = filter_custom_options['lookup_kwarg']
+            assert lookup_kwarg == expected_lookup_kwargs[option_field_name]
+
+            if option_field_name in ['author', 'audience', 'tags']:
                 validator = MatchingTagValidator(
+                    'select',
+                    {'name': option_field_name},
                     {
                         'class': 'django-admin-list-filter admin-autocomplete',
-                        'name': option_field_name,
-                        'data-lookup-kwarg': f'{option_field_name}{maybe_id_suffix}__exact',
                         'data-theme': 'admin-autocomplete',
+                        'name': option_field_name,
+                        'data-lookup-kwarg': lookup_kwarg,
                     },
-                    {'name': option_field_name},
-                    'select',
                 )
                 validator.check(content)
 
-            if option_field_name == 'author':
-                for author in post_authors:
-                    assert f'{author}</option>' in content
+                for internal, human in target_options[option_field_name].items():
+                    validator = MatchingTagValidator(
+                        'option',
+                        {'value': f'?{lookup_kwarg}={internal}'},
+                        {},
+                        human
+                    )
+                    validator.check(content)
 
-            if option_field_name == 'audience':
-                for audience in post_audiences:
-                    assert f'<option value="?audience__exact={audience}">' in content
-
-            if option_field_name == 'category':
-                assert 'data-field-name="category"></select>' in content
+            elif option_field_name in ['category', 'category_renamed']:
+                validator = MatchingTagValidator(
+                    'select',
+                    {'data-field-name': option_field_name},
+                    {
+                        'class': 'django-admin-list-filter-ajax',
+                        'data-theme': 'admin-autocomplete',
+                        'data-allow-clear': 'true',
+                        'data-lookup-kwarg': lookup_kwarg,
+                        'data-app-label': 'testapp',
+                        'data-model-name': 'post',
+                        'data-field-name': option_field_name,
+                    },
+                )
+                validator.check(content)
 
                 url_params = '&'.join(
                     [f'{key}={value}' for key, value in filter_custom_options.items() if key != 'selected_value']
@@ -98,13 +140,24 @@ def test_post_admin_filters_basics(admin_client, posts):  # noqa: ARG001
                 ajax_resonse = admin_client.get(f'/admin/autocomplete/?{url_params}')
 
                 assert ajax_resonse['Content-Type'] == 'application/json'
-
                 json_response = ajax_resonse.json()
                 assert json_response
 
                 results = json_response.get('results')
-                pagination = json_response.get('pagination', {}).get('more', None)
-
                 assert len(results) == 1
-                assert pagination is not None
+                # Even when not named `id`, autocomplete AJAX will helpfully call it so:
+                assert 'id' in results[0]
+
+                pagination = json_response.get('pagination', {}).get('more', None)
                 assert pagination is False
+            else:
+                pytest.fail(f'Unexpected field: {option_field_name}')
+
+    # Must not include tags that have no associated Posts.
+    validator = MatchingTagValidator(
+        'option',
+        {'value': f'?tags__id__exact={unused_tag.pk}'},
+        {}
+    )
+    validator.feed(content)
+    assert not validator.seen_target_tag


### PR DESCRIPTION
Fixes #16. 

Django models do not always have a field named "id". Declaring another field with `primary_key=True` removes the default `id` field. 

Admin `*ListFilter` variations all have `lookup_kwarg` attribute that provides exactly what we need: explicit target lookup without any string munging in application code. This also allows us to remove `isChoiceField` entirely and always use the `lookup_kwarg` provided by Django. Autocomplete AJAX always returns PK field under `id` field.

I tested these changes locally on a test project and adjusted the existing test to account for new fields. To support usual whitespace wrapping, I replaced string-based asserts with HTMLParser (built-in) to verify that there is exactly one tag matching given specification.