### PR TITLE
Fix: '-' (None/isnull) filter option silently clears filter instead of applying it

### DIFF
--- a/src/dalf/static/admin/js/django_admin_list_filter.js
+++ b/src/dalf/static/admin/js/django_admin_list_filter.js
@@ -124,21 +124,18 @@
     $(document).ready(function() {
         $('.django-admin-list-filter').select2({
         }).on("select2:select", function(e){
-            var navURL = new URL(window.location.href);
-            let [fieldQueryParam, queryParams] = getQueryParams(e);
-            var isAllorEmptyChoice = true;
-
-            queryParams.forEach(function(item){
-                var [field, value] = item.split("=");
-                if (field == fieldQueryParam) {
-                    isAllorEmptyChoice = false;
-                    navURL.searchParams.set(field, decodeURIComponent(value));
-                }
-            });
-            if (isAllorEmptyChoice) {
-                navURL.searchParams.delete(fieldQueryParam);
-            }
-            window.location.href = navURL.href;
+            // Navigate directly to the pre-computed query string that Django embeds
+            // in each option's value attribute. This handles all three cases correctly:
+            //   - Specific value:  ?field__id__exact=5
+            //   - All (no filter): ?...                (filter param removed)
+            //   - None / isnull:   ?field__isnull=True
+            //
+            // The previous URL-reconstruction approach only matched the __exact param
+            // against data-lookup-kwarg; the __isnull option uses a different param
+            // name so it was never matched, isAllorEmptyChoice stayed true, and the
+            // handler cleared the filter instead of applying it -- making the "-" (None)
+            // option appear to do nothing.
+            window.location.search = e.params.data.id;
 
         }).on("select2:unselect", function(e){
             var navURL = new URL(window.location.href);


### PR DESCRIPTION
## Bug

For nullable FK fields, Django's `RelatedFieldListFilter` emits a \"None\" choice at the bottom of the list, displayed as `-` (the admin's `empty_value_display`). Selecting it is supposed to filter for records where the FK is null — but with DALF it silently clears the filter and shows all records instead.

## Root cause

The `select2:select` handler reconstructs the URL by parsing the selected option's value (the pre-computed query string) and looking for a param whose name matches `data-lookup-kwarg` (the `__exact` param, e.g. `machine__id__exact`).

The None/isnull choice uses a *different* param name (`machine__isnull`), so it is never matched. `isAllorEmptyChoice` stays `true`, and the handler falls through to `navURL.searchParams.delete(fieldQueryParam)` — clearing the filter rather than setting it.

## Fix

Django already pre-computes the correct, complete query string for every option (including All, specific values, and isnull). There is no need to reconstruct it in JS — just navigate there directly:

```js
window.location.search = e.params.data.id;
```

This is simpler and handles all three option types correctly:
- Specific value: `?field__id__exact=5`
- All (no filter): query string with filter param removed
- None / isnull: `?field__isnull=True`

## Affected filters

`DALFRelatedField` and `DALFRelatedOnlyField` — any nullable FK field in a DALF list filter.

## Reproduction

1. Have a model with a nullable FK field
2. Register it in admin with a DALF list filter on that field
3. Select the `-` option in the filter dropdown
4. Expected: list filtered to records where FK is null
5. Actual: filter is cleared, all records shown